### PR TITLE
Wrap optional imports

### DIFF
--- a/memvid/encoder.py
+++ b/memvid/encoder.py
@@ -9,9 +9,26 @@ import tempfile
 import warnings
 from pathlib import Path
 from typing import List, Optional, Dict, Any
-from tqdm import tqdm
-import cv2
-import numpy as np
+try:
+    from tqdm import tqdm
+except ImportError as e:
+    raise ImportError(
+        "tqdm is required for progress display. Install it with `pip install tqdm`."
+    ) from e
+
+try:
+    import cv2
+except ImportError as e:
+    raise ImportError(
+        "OpenCV (cv2) is required for video processing. Install it with `pip install opencv-python`."
+    ) from e
+
+try:
+    import numpy as np
+except ImportError as e:
+    raise ImportError(
+        "NumPy is required for numerical operations. Install it with `pip install numpy`."
+    ) from e
 
 from .utils import encode_to_qr, qr_to_frame, chunk_text
 from .index import IndexManager

--- a/memvid/index.py
+++ b/memvid/index.py
@@ -3,14 +3,36 @@ Index management for embeddings and vector search
 """
 
 import json
-import numpy as np
-import faiss
-from sentence_transformers import SentenceTransformer
+try:
+    import numpy as np
+except ImportError as e:
+    raise ImportError(
+        "NumPy is required for numerical operations. Install it with `pip install numpy`."
+    ) from e
+
+try:
+    import faiss
+except ImportError as e:
+    raise ImportError(
+        "faiss is required for vector indexing. Install it with `pip install faiss-cpu` or `faiss-gpu`."
+    ) from e
+
+try:
+    from sentence_transformers import SentenceTransformer
+except ImportError as e:
+    raise ImportError(
+        "sentence-transformers is required for text embeddings. Install it with `pip install sentence-transformers`."
+    ) from e
 from typing import List, Dict, Any, Tuple, Optional
 import logging
 from pathlib import Path
 import pickle
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError as e:
+    raise ImportError(
+        "tqdm is required for progress display. Install it with `pip install tqdm`."
+    ) from e
 
 from .config import get_default_config
 
@@ -170,10 +192,17 @@ class IndexManager:
         total_batches = (len(chunks) + batch_size - 1) // batch_size
 
         if show_progress:
-            from tqdm import tqdm
-            batch_iter = tqdm(range(0, len(chunks), batch_size),
-                              desc="Processing chunks in batches",
-                              total=total_batches)
+            try:
+                from tqdm import tqdm
+            except ImportError as e:
+                raise ImportError(
+                    "tqdm is required for progress display. Install it with `pip install tqdm`."
+                ) from e
+            batch_iter = tqdm(
+                range(0, len(chunks), batch_size),
+                desc="Processing chunks in batches",
+                total=total_batches,
+            )
         else:
             batch_iter = range(0, len(chunks), batch_size)
 

--- a/memvid/utils.py
+++ b/memvid/utils.py
@@ -5,14 +5,30 @@ Shared utility functions for Memvid
 import io
 import json
 import qrcode
-import cv2
-import numpy as np
+try:
+    import cv2
+except ImportError as e:
+    raise ImportError(
+        "OpenCV (cv2) is required for image processing. Install it with `pip install opencv-python`."
+    ) from e
+
+try:
+    import numpy as np
+except ImportError as e:
+    raise ImportError(
+        "NumPy is required for numerical operations. Install it with `pip install numpy`."
+    ) from e
 from PIL import Image
 from typing import List, Tuple, Optional, Dict, Any
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from functools import lru_cache
 import logging
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError as e:
+    raise ImportError(
+        "tqdm is required for progress display. Install it with `pip install tqdm`."
+    ) from e
 import base64
 import gzip
 


### PR DESCRIPTION
## Summary
- prevent import failures from missing dependencies
- show more helpful error messages for numpy, tqdm, cv2, faiss, and sentence-transformers

## Testing
- `pip install -q -r requirements.txt` *(fails: swig not found)*
- `pytest -q` *(fails: ModuleNotFoundError for tqdm and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68465d72aa2083268b3f36c14accb258