### PR TITLE
Fix build_memory video_file path

### DIFF
--- a/examples/build_memory.py
+++ b/examples/build_memory.py
@@ -72,7 +72,7 @@ def main():
     output_dir = "output"
     os.makedirs(output_dir, exist_ok=True)
     
-    video_file = os.path.join(output_dir, f"memory.{VIDEO_FILE_TYPE}]")
+    video_file = os.path.join(output_dir, f"memory.{VIDEO_FILE_TYPE}")
     index_file = os.path.join(output_dir, "memory_index.json")
     
     print(f"\nBuilding video: {video_file}")


### PR DESCRIPTION
## Summary
- fix `video_file` path in `examples/build_memory.py`

## Testing
- `python -m py_compile examples/build_memory.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'faiss')*

------
https://chatgpt.com/codex/tasks/task_e_68465d7a305083268cd4ba5bac5c0127