### PR TITLE
Document libzbar requirement for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,16 @@ pytest --cov=memvid tests/
 black memvid/
 ```
 
+### Running Unit Tests
+
+The `decode_qr` helper used in the test suite depends on the system
+library `libzbar0`. Ensure it is installed before running tests:
+
+```bash
+sudo apt-get install libzbar0    # Ubuntu/Debian
+brew install zbar                # macOS
+```
+
 ## 🆚 Comparison with Traditional Solutions
 
 | Feature | Memvid | Vector DBs | Traditional DBs |


### PR DESCRIPTION
## Summary
- note that running tests and decode_qr needs libzbar0
- provide apt and brew install commands

## Testing
- `pytest -q` *(fails: ProxyError & missing zbar)*

------
https://chatgpt.com/codex/tasks/task_e_68468e7005b88326bb1164bb2ee6649c