### PR TITLE
Add PDF-based QA example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ memvid.egg-info/
 memvid.egg-info/*
 dist/memvid-*/
 
+data/ipa_guidelines.pdf

--- a/examples/ipa_doc_qa.py
+++ b/examples/ipa_doc_qa.py
@@ -1,0 +1,58 @@
+import os
+import time
+from pathlib import Path
+from dotenv import load_dotenv
+from memvid import MemvidEncoder, MemvidChat
+
+PDF_URL = "https://www.ipa.go.jp/jinzai/ics/core_human_resource/final_project/2024/f55m8k0000003spo-att/f55m8k0000003svn.pdf"
+PDF_PATH = Path("data/ipa_guidelines.pdf")
+VIDEO_PATH = Path("output/ipa_memory.mp4")
+INDEX_PATH = Path("output/ipa_memory_index.json")
+
+QUESTIONS = [
+    "概要を教えてください。",
+    "生成AIを企業が利用する上で重要なことを教えてください。",
+    "今後の生成AIの成長率について教えてください。",
+]
+
+def download_pdf():
+    if not PDF_PATH.exists():
+        import requests
+        PDF_PATH.parent.mkdir(parents=True, exist_ok=True)
+        print(f"Downloading {PDF_URL} ...")
+        resp = requests.get(PDF_URL)
+        resp.raise_for_status()
+        with open(PDF_PATH, "wb") as f:
+            f.write(resp.content)
+        print(f"Saved to {PDF_PATH}")
+
+
+def build_memory():
+    if VIDEO_PATH.exists() and INDEX_PATH.exists():
+        return
+    encoder = MemvidEncoder()
+    encoder.add_pdf(str(PDF_PATH))
+    VIDEO_PATH.parent.mkdir(exist_ok=True)
+    print("Building memory ...")
+    encoder.build_video(str(VIDEO_PATH), str(INDEX_PATH), show_progress=False)
+
+
+def answer_questions():
+    chat = MemvidChat(str(VIDEO_PATH), str(INDEX_PATH), llm_provider="openai")
+    for q in QUESTIONS:
+        start = time.time()
+        answer = chat.chat(q)
+        elapsed = time.time() - start
+        print("Q:", q)
+        print("A:", answer)
+        print(f"回答時間: {elapsed:.2f}秒\n")
+
+
+def main():
+    load_dotenv()
+    download_pdf()
+    build_memory()
+    answer_questions()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add IPA guideline PDF to `.gitignore`
- add script `ipa_doc_qa.py` to build a memory from the PDF and query it

## Testing
- `pip install -q -r requirements.txt`
- `python examples/ipa_doc_qa.py` *(fails: ProxyError when downloading model)*
- `pytest -q` *(fails: ProxyError when downloading model)*


------
https://chatgpt.com/codex/tasks/task_e_6848cacb90fc83268353ec9d1ac3bf5b